### PR TITLE
Regenerate the launch package using the latest changes of the Tooling…

### DIFF
--- a/Example_cob_robot/cob_teleop_robot/src-gen/cob_teleop_robot/launch/cob_teleop_robot.launch.py
+++ b/Example_cob_robot/cob_teleop_robot/src-gen/cob_teleop_robot/launch/cob_teleop_robot.launch.py
@@ -40,7 +40,6 @@ def generate_launch_description():
     output='screen',
     name="joy_node",
     remappings=[
-      ("joy", "joy_pub"),
       ("joy", "joy_pub")]
     ,
     parameters=[{
@@ -56,8 +55,6 @@ def generate_launch_description():
     name="twist_mux",
     remappings=[
       ("cmd_vel_out", "/base/twist_controller/command"),
-      ("cmd_vel", "cmd_vel_sub"),
-      ("cmd_vel_out", "/base/twist_controller/command"),
       ("cmd_vel", "cmd_vel_pub")]
     ,
     parameters = [twist_mux_config]
@@ -69,8 +66,6 @@ def generate_launch_description():
     output='screen',
     name="teleop_twist_joy_node",
     remappings=[
-      ("joy", "joy_sub"),
-      ("cmd_vel", "cmd_vel_pub"),
       ("joy", "joy_pub"),
       ("cmd_vel", "cmd_vel_pub")]
     ,

--- a/Example_cob_robot/cob_teleop_robot/src-gen/cob_teleop_robot/launch/cob_teleop_robot_bridges.launch.py
+++ b/Example_cob_robot/cob_teleop_robot/src-gen/cob_teleop_robot/launch/cob_teleop_robot_bridges.launch.py
@@ -1,9 +1,11 @@
 import os
+from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch_ros.actions import Node
-from launch.actions import IncludeLaunchDescription, DeclareLaunchArgument, ExecuteProcess
+from launch.actions import IncludeLaunchDescription, DeclareLaunchArgument, ExecuteProcess, RegisterEventHandler, LogInfo
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PythonExpression, PathJoinSubstitution, TextSubstitution
+from launch.event_handlers import OnProcessExit, OnExecutionComplete
 
 def generate_launch_description():
   ld = LaunchDescription()
@@ -16,7 +18,7 @@ def generate_launch_description():
   )
 
   load_bridge_params = ExecuteProcess(
-      cmd=['rosparam', load, cob_teleop_robot_ros1_bridge_config]
+      cmd=['rosparam', 'load', cob_teleop_robot_ros1_bridge_config]
   )
 
   ros1_topic_bridge_parameter_bridge = ExecuteProcess(
@@ -31,8 +33,7 @@ def generate_launch_description():
           LogInfo(msg='Load bridge parameter finished'),
           LogInfo(msg='launching bridge for topics'),
           ros1_topic_bridge_parameter_bridge,
-          LogInfo(msg='Start loading bridge parameters'),
-          load_bridge_params]
+          LogInfo(msg='Start loading bridge parameters')]
       )
     ),
     load_bridge_params


### PR DESCRIPTION
… i.e., https://github.com/ipa320/RosTooling/tree/68ae72d8e47d2de71c6c8bd0a7e1a7c81075aa19

I made the changes on the dev version of the RosTooling:
- I took your suggestions for the bridges generator: https://github.com/ipa320/RosTooling/commit/aca2b50824f2d0276a94106916f156f5b9f989e2 (you are a co-author of the commit)
- I fixed the issue with duplicated interfaces by ignoring the remaps of the interface in case the connection forces already the remap: https://github.com/ipa320/RosTooling/commit/68ae72d8e47d2de71c6c8bd0a7e1a7c81075aa19

The new generated files are in this commit. What do you think? Are now the issues solved?